### PR TITLE
Feature/set raw token on jwt

### DIFF
--- a/src/Jwt.php
+++ b/src/Jwt.php
@@ -3,6 +3,7 @@
 namespace HalloVerden\JwtAuthenticatorBundle;
 
 final class Jwt {
+  private ?string $rawToken = null;
 
   /**
    * Jwt constructor.
@@ -43,6 +44,23 @@ final class Jwt {
    */
   public function getHeader(string $key): mixed {
     return $this->headers[$key] ?? null;
+  }
+
+  /**
+   * @return string|null
+   */
+  public function getRawToken(): ?string {
+    return $this->rawToken;
+  }
+
+  /**
+   * @param string|null $rawToken
+   *
+   * @return self
+   */
+  public function setRawToken(?string $rawToken): self {
+    $this->rawToken = $rawToken;
+    return $this;
   }
 
 }

--- a/src/Jwt.php
+++ b/src/Jwt.php
@@ -3,14 +3,14 @@
 namespace HalloVerden\JwtAuthenticatorBundle;
 
 final class Jwt {
-  private ?string $rawToken = null;
 
   /**
    * Jwt constructor.
    */
   public function __construct(
     private readonly array $claims,
-    private readonly array $headers
+    private readonly array $headers,
+    private readonly ?string $rawToken = null
   ) {
   }
 
@@ -51,16 +51,6 @@ final class Jwt {
    */
   public function getRawToken(): ?string {
     return $this->rawToken;
-  }
-
-  /**
-   * @param string|null $rawToken
-   *
-   * @return self
-   */
-  public function setRawToken(?string $rawToken): self {
-    $this->rawToken = $rawToken;
-    return $this;
   }
 
 }

--- a/src/Services/JwtService.php
+++ b/src/Services/JwtService.php
@@ -28,7 +28,7 @@ class JwtService implements JwtServiceInterface {
    */
   public function parseAndVerify(string $token): Jwt {
     try {
-      $jwt = $this->getJwt($token);
+      $jwt = $this->getJwt($token)->setRawToken($token);
     } catch (\Exception $e) {
       throw new InvalidTokenException($e->getMessage(), 0, $e);
     }

--- a/src/Services/JwtService.php
+++ b/src/Services/JwtService.php
@@ -28,7 +28,7 @@ class JwtService implements JwtServiceInterface {
    */
   public function parseAndVerify(string $token): Jwt {
     try {
-      $jwt = $this->getJwt($token)->setRawToken($token);
+      $jwt = $this->getJwt($token);
     } catch (\Exception $e) {
       throw new InvalidTokenException($e->getMessage(), 0, $e);
     }
@@ -50,7 +50,7 @@ class JwtService implements JwtServiceInterface {
    */
   private function getJwt(string $token): Jwt {
     $jws = $this->jwsLoader->loadAndVerifyWithKeySet($token, $this->jwkSet, $signature);
-    return new Jwt(JsonConverter::decode($jws->getPayload()), $jws->getSignature($signature)->getProtectedHeader());
+    return new Jwt(JsonConverter::decode($jws->getPayload()), $jws->getSignature($signature)->getProtectedHeader(), $token);
   }
 
 }


### PR DESCRIPTION
Sometimes we need to get the raw token, before the authentication token i created (e.g. when creating the user).
We already have access to the `Jwt` object, so putting it there is very handy.