### PR TITLE
Feature/support user provider per authenticator

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,16 +58,19 @@ security:
   firewalls:
     main:
       hallo_verden_jwt:
-        jwt_name:
-          key_set: 'my_key_set'
-          jws_loader: 'hallo_verden_default'
-          claim_checker: 'hallo_verden_default'
-          mandatory_claims: []
-          user_identifier_claim: 'sub'
-          token_extractor: 'hallo_verden.token_extractor.bearer'
-          failure_handler: ~
-        some_other_jwt:
-          key_set: 'my_ket_set'
+        provider: 'user_provider'
+        tokens:
+          jwt_name:
+            key_set: 'my_key_set'
+            jws_loader: 'hallo_verden_default'
+            claim_checker: 'hallo_verden_default'
+            mandatory_claims: []
+            user_identifier_claim: 'sub'
+            token_extractor: 'hallo_verden.token_extractor.bearer'
+            failure_handler: ~
+            provider: 'user_provider'
+          some_other_jwt:
+            key_set: 'my_ket_set'
 ```
 
 For each key in `hallo_verden_jwt` an authenticator is created.

--- a/src/DependencyInjection/Security/Factory/JwtAuthenticatorFactory.php
+++ b/src/DependencyInjection/Security/Factory/JwtAuthenticatorFactory.php
@@ -54,6 +54,7 @@ class JwtAuthenticatorFactory implements AuthenticatorFactoryInterface {
           ->scalarNode('token_extractor')->defaultValue('hallo_verden.token_extractor.bearer')->end()
           ->scalarNode('user_identifier_claim')->defaultValue('sub')->end()
           ->scalarNode('failure_handler')->end()
+          ->scalarNode('provider')->defaultNull()->end()
         ->end()
       ->end();
 
@@ -76,6 +77,8 @@ class JwtAuthenticatorFactory implements AuthenticatorFactoryInterface {
   private function _createAuthenticator(ContainerBuilder $container, string $firewallName, array $config, string $userProviderId, string $key): string {
     $authenticatorId = 'security.authenticator.hallo_verden_jwt.'.$key.'.'.$firewallName;
     $jwtServiceId = 'hallo_verden.jwt_service.'.$key.'.'.$firewallName;
+
+    $userProviderId = isset($config['provider']) ? 'security.user.provider.concrete.' . \strtolower($config['provider']) : $userProviderId;
 
     $mandatoryClaims = $config['mandatory_claims'];
     if (\in_array($config['user_identifier_claim'], $mandatoryClaims)) {


### PR DESCRIPTION
Adds the ability to set a user provider per authenticator (per token).

This also updates the configuration structure (the old structure is still supported).
old:
```yaml
hallo_verden_jwt:
  token1: []
  token2: []
```
new:
```yaml
hallo_verden_jwt:
  tokens:
    token1: []
    token2: []
```